### PR TITLE
Add log parsing code

### DIFF
--- a/lib/logparser.rb
+++ b/lib/logparser.rb
@@ -1,0 +1,37 @@
+require 'json'
+
+class LogParser
+  # Parses a file containing JSON documents, each on its own line.
+  # When in strict mode, lines which do not parse as valid JSON documents
+  # raise exceptions, otherwise they are ignored.
+  # 
+  # Example usage:
+  #
+  # LogParser::new(open('log.txt'), strict: false).each_record {|document|
+  #     # do something with document
+  #     puts document.inspect
+  # }
+  def initialize(log_file, options={})
+    @log_file = log_file
+
+    @strict = options.include?(:strict) ? options[:strict] : true
+  end
+
+
+  def each_record(&block)
+    loop do
+      begin
+        line = @log_file.readline
+      rescue EOFError
+        break
+      end
+      begin
+        yield JSON.load(line)
+      rescue JSON::ParserError
+        if @strict
+          raise
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/logparser_spec.rb
+++ b/spec/lib/logparser_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+require 'logparser'
+
+
+
+RSpec.describe LogParser do
+  TEST_FILE_WITH_PARSE_ERROR = <<-END
+    {"a": 1, "b": 4}
+    {"a": 2, "b": 5}
+    {"a": 3, "b": 6}
+    foobar
+    {"a": 4, "b": 7}
+    END
+
+  it "ignores invalid documents without strict mode" do
+    file = StringIO::new(TEST_FILE_WITH_PARSE_ERROR)
+    parser = LogParser::new(file, strict: false)
+
+    document_counter = 0
+    parser.each_record {|rec|
+      document_counter += 1
+    }
+
+    expect(document_counter).to be(4)
+  end
+
+  it "raises exceptions on invalid documents when in strict mode" do
+    file = StringIO::new(TEST_FILE_WITH_PARSE_ERROR)
+
+    # strict is default
+    parser = LogParser::new(file)
+
+    document_counter = 0
+    expect{
+      parser.each_record {|rec|
+        document_counter += 1
+      }
+    }.to raise_error(JSON::ParserError)
+
+    # ensure we hit the exception at the right point and not earlier.
+    expect(document_counter).to be(3)
+  end
+end


### PR DESCRIPTION
Hi,

This change adds a log-parsing helper functions to the rails app which will later be consumed by a script which can read files for insertion into the database.

Lines which do not parse as valid JSON documents are currently ignored.
